### PR TITLE
Replace expression with DOC_VALID

### DIFF
--- a/pinner.c
+++ b/pinner.c
@@ -245,7 +245,7 @@ unpin_activate_cb(GtkMenuItem* menuitem, gpointer pdata)
   gchar* ptr_file_name = pdata;
 
   if (!pdata) {
-    if (!(doc && doc->is_valid))
+    if (!DOC_VALID(doc))
       return;
 
     if (doc->file_name == NULL)

--- a/pinner.c
+++ b/pinner.c
@@ -195,9 +195,8 @@ pin_activate_cb(GtkMenuItem* menuitem, gpointer pdata)
   (void)pdata;
 
   GeanyDocument* doc = document_get_current();
-  if (!(doc && doc->is_valid))
+  if (!DOC_VALID(doc))
     return;
-
   // See https://github.com/geany/geany/pull/3770 for more info on
   // Why this check is necessary even after checking if doc == NULL
   if (doc->file_name == NULL)


### PR DESCRIPTION
@elextr I still need the extra 'doc->file_name' check otherwise Geany crashes if the user has an 'untitled' document in front of them. Not a typical use case, but I encountered the crash by accident just a couple days after using the plug-in.

(Related to discussion at https://github.com/geany/geany-plugins/pull/1308#issuecomment-1953291869)